### PR TITLE
feat(mvcc): 事务支持Range查询

### DIFF
--- a/src/kernel/lsm/mem_table.rs
+++ b/src/kernel/lsm/mem_table.rs
@@ -171,7 +171,7 @@ impl MemTable {
             logs_decode(log_bytes)?
                 .map(|(key, value)| (InternalKey::new_with_seq(key, 0), value))
         );
-        let (trigger_type, threshold) = config.minor_trigger_with_threshold.clone();
+        let (trigger_type, threshold) = config.minor_trigger_with_threshold;
 
         Ok(MemTable {
             inner: Mutex::new(TableInner {

--- a/src/kernel/lsm/trigger.rs
+++ b/src/kernel/lsm/trigger.rs
@@ -30,7 +30,7 @@ pub(crate) struct SizeOfMemTrigger {
 
 impl Trigger for SizeOfMemTrigger {
     fn item_process(&mut self, item: &KeyValue) {
-        self.size_of_mem += key_value_bytes_len(&item);
+        self.size_of_mem += key_value_bytes_len(item);
     }
 
     fn is_exceeded(&self) -> bool {

--- a/src/kernel/lsm/version.rs
+++ b/src/kernel/lsm/version.rs
@@ -423,9 +423,11 @@ impl Version {
     /// 把当前version的leveSlice中的数据转化为一组versionEdit 作为新version_log的base
     pub(crate) fn to_vec_edit(&self) -> Vec<VersionEdit> {
         fn sst_meta_with_level(level: usize, size_of_disk: u64, len: usize) -> SSTableMeta {
-            (LEVEL_0 == level)
-                .then(|| SSTableMeta { size_of_disk, len })
-                .unwrap_or(SSTableMeta::default())
+            if LEVEL_0 == level {
+                SSTableMeta { size_of_disk, len }
+            } else {
+                SSTableMeta::default()
+            }
         }
 
         self.level_slice.iter()


### PR DESCRIPTION
### What problem does this PR solve?
在LSMStore本身支持full_iter进行整体锁定范围读取的情况下，使用事务新增range_scan实现可并发的范围读取

### What is changed and how it works?
结合VersionIter、Memtable::range以及事务本身writer_buf中range归并有序化实现范围读取

数据优先级(重复数据唯一化基准)
1. Transaction.writer_buf
2. MemTable
3. Version(SSTables)

### Code changes
- [ mvcc.rs] Has Rust code change

### Check List
基于原有单测方法新增了range_scan的测试场景，Check该场景对该功能覆盖有什么不到位

### Note for reviewer
顺带修改了其他三个文件的中clippy提出的可优化调整，可以忽视