### PR TITLE
fix(trigger): Add a reset method

### DIFF
--- a/src/kernel/lsm/mem_table.rs
+++ b/src/kernel/lsm/mem_table.rs
@@ -250,6 +250,8 @@ impl MemTable {
                     continue
                 }
                 return if !inner._mem.is_empty() {
+                    inner.trigger.reset();
+                    
                     let mut vec_data = inner._mem.iter()
                         .map(|(k, v)| (k.key.clone(), v.clone()))
                         // rev以使用最后(最新)的key

--- a/src/kernel/lsm/trigger.rs
+++ b/src/kernel/lsm/trigger.rs
@@ -4,6 +4,8 @@ pub(crate) trait Trigger {
     fn item_process(&mut self, item: &KeyValue);
 
     fn is_exceeded(&self) -> bool;
+
+    fn reset(&mut self);
 }
 
 #[derive(Copy, Clone)]
@@ -20,6 +22,10 @@ impl Trigger for CountTrigger {
     fn is_exceeded(&self) -> bool {
         self.item_count >= self.threshold
     }
+
+    fn reset(&mut self) {
+        self.item_count = 0;
+    }
 }
 
 #[derive(Copy, Clone)]
@@ -35,6 +41,10 @@ impl Trigger for SizeOfMemTrigger {
 
     fn is_exceeded(&self) -> bool {
         self.size_of_mem >= self.threshold
+    }
+
+    fn reset(&mut self) {
+        self.size_of_mem = 0;
     }
 }
 


### PR DESCRIPTION
 clear the cumulative value of triggers to avoid the threshold judgment remaining true after Swap

### What problem does this PR solve?

fix bug for trigger judgment threshold is always true

Issue link: https://github.com/KipData/KipDB/issues/22

### What is changed and how it works?

add reset method to reset the trigger

### Code changes

- [ tigger.rs, mem_table.rs ] Has Rust code change
