### PR TITLE
Feat/seek compaction

### DIFF
--- a/src/bench/kernel_bench.rs
+++ b/src/bench/kernel_bench.rs
@@ -5,8 +5,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering::Relaxed;
 
-use kip_db::kernel::lsm::storage::LsmStore;
-use kip_db::kernel::sled_storage::SledStore;
+use kip_db::kernel::lsm::storage::KipStorage;
+use kip_db::kernel::sled_storage::SledStorage;
 use kip_db::kernel::Storage;
 
 fn counter() -> usize {
@@ -182,23 +182,23 @@ fn empty_opens<T: Storage>(c: &mut Criterion) {
 }
 
 fn kv_bulk_load(c: &mut Criterion) {
-    bulk_load::<LsmStore>(c);
-    bulk_load::<SledStore>(c);
+    bulk_load::<KipStorage>(c);
+    bulk_load::<SledStorage>(c);
 }
 
 fn kv_monotonic_crud(c: &mut Criterion) {
-    monotonic_crud::<LsmStore>(c);
-    monotonic_crud::<SledStore>(c);
+    monotonic_crud::<KipStorage>(c);
+    monotonic_crud::<SledStorage>(c);
 }
 
 fn kv_random_crud(c: &mut Criterion) {
-    random_crud::<LsmStore>(c);
-    random_crud::<SledStore>(c);
+    random_crud::<KipStorage>(c);
+    random_crud::<SledStorage>(c);
 }
 
 fn kv_empty_opens(c: &mut Criterion) {
-    empty_opens::<LsmStore>(c);
-    empty_opens::<SledStore>(c);
+    empty_opens::<KipStorage>(c);
+    empty_opens::<SledStorage>(c);
 }
 
 criterion_group!(

--- a/src/kernel/lsm/compactor.rs
+++ b/src/kernel/lsm/compactor.rs
@@ -100,11 +100,11 @@ impl Compactor {
 
     /// Major压缩，负责将不同Level之间的数据向下层压缩转移
     /// 目前Major压缩的大体步骤是
-    /// 1. 获取当前Version，通过传入的指定Scope得到下一Level与该scope相交的SSTable，命名为tables_ll
-    /// 2. 获取的tables_ll向上一Level进行类似第2步骤的措施，获取两级之间压缩范围内最恰当的数据
+    /// 1. 获取当前Version，通过传入的指定Scope得到该Level与该scope相交的SSTable，命名为tables_l
+    /// 2. 获取的tables_l向下一级Level进行类似第2步骤的措施，获取两级之间压缩范围内最恰当的数据(table_ll的范围应当左右应包含与table_l)
     /// 3. tables_l与tables_ll之间的数据并行取出排序归并去重等处理后，分片成多个Vec<KeyValue>
     /// 4. 并行将每个分片各自生成SSTable
-    /// 5. 生成的SSTables插入到tables_l的第一个SSTable位置，并将tables_l和tables_ll的SSTable删除
+    /// 5. 生成的SSTables插入到tables_ll的第一个SSTable位置，并将tables_l和tables_ll的SSTable删除
     /// 6. 将变更的SSTable插入至vec_ver_edit以持久化
     /// Final: 将vec_ver_edit中的数据进行log_and_apply生成新的Version作为最新状态
     ///

--- a/src/kernel/lsm/iterator/full_iter.rs
+++ b/src/kernel/lsm/iterator/full_iter.rs
@@ -48,7 +48,7 @@ impl<'a> Iter<'a> for FullIter<'a> {
 #[cfg(test)]
 mod tests {
     use crate::kernel::lsm::iterator::Iter;
-    use crate::kernel::lsm::storage::{Config, LsmStore};
+    use crate::kernel::lsm::storage::{Config, KipStorage};
     use crate::kernel::lsm::version::iter::VersionIter;
     use crate::kernel::{Result, Storage};
     use bincode::Options;
@@ -68,7 +68,7 @@ mod tests {
 
             let config =
                 Config::new(temp_dir.path().to_str().unwrap()).major_threshold_with_sst_size(4);
-            let kv_store = LsmStore::open_with_config(config).await?;
+            let kv_store = KipStorage::open_with_config(config).await?;
             let mut vec_kv = Vec::new();
 
             for i in 100..times + 100 {

--- a/src/kernel/lsm/mod.rs
+++ b/src/kernel/lsm/mod.rs
@@ -14,7 +14,6 @@ mod version;
 
 /// KeyValue数据分片，尽可能将数据按给定的分片大小：file_size，填满一片（可能会溢出一些）
 /// 保持原有数据的顺序进行分片，所有第一片分片中最后的值肯定会比其他分片开始的值Key排序较前（如果vec_data是以Key从小到大排序的话）
-/// TODO: Block对齐封装,替代此方法
 fn data_sharding(mut vec_data: Vec<KeyValue>, file_size: usize) -> MergeShardingVec {
     // 向上取整计算SSTable数量
     let part_size =

--- a/src/kernel/lsm/mod.rs
+++ b/src/kernel/lsm/mod.rs
@@ -1,7 +1,6 @@
 use crate::kernel::lsm::compactor::{CompactTask, MergeShardingVec};
 use crate::kernel::lsm::mem_table::{key_value_bytes_len, KeyValue};
 use crate::kernel::lsm::storage::Gen;
-use crate::kernel::lsm::table::scope::Scope;
 use crate::kernel::lsm::version::{SeekOption, Version};
 use crate::kernel::Result;
 use crate::KernelError;
@@ -60,10 +59,9 @@ fn query_and_compaction(
 ) -> Result<Option<Bytes>> {
     match version.query(key)? {
         SeekOption::Hit(value) => return Ok(Some(value)),
-        SeekOption::Miss(Some(level)) => {
-            let scope = Scope::from_key(key);
+        SeekOption::Miss(Some(seek_scope)) => {
             compactor_tx
-                .try_send(CompactTask::Seek(scope, level))
+                .try_send(CompactTask::Seek(seek_scope))
                 .map_err(|_| KernelError::ChannelClose)?;
         }
         _ => (),

--- a/src/kernel/lsm/mvcc.rs
+++ b/src/kernel/lsm/mvcc.rs
@@ -161,7 +161,7 @@ impl Transaction {
 /// TODO: 更多的Test Case
 #[cfg(test)]
 mod tests {
-    use crate::kernel::lsm::storage::{Config, LsmStore};
+    use crate::kernel::lsm::storage::{Config, KipStorage};
     use crate::kernel::{Result, Storage};
     use bincode::Options;
     use bytes::Bytes;
@@ -181,7 +181,7 @@ mod tests {
             there with a sign.";
 
             let config = Config::new(temp_dir.into_path()).major_threshold_with_sst_size(4);
-            let kv_store = LsmStore::open_with_config(config).await?;
+            let kv_store = KipStorage::open_with_config(config).await?;
 
             let mut vec_kv = Vec::new();
 

--- a/src/kernel/lsm/storage.rs
+++ b/src/kernel/lsm/storage.rs
@@ -212,8 +212,10 @@ impl KipStorage {
         let _ignore = tokio::spawn(async move {
             while let Some(task) = task_rx.recv().await {
                 match task {
-                    CompactTask::Seek(scope, level) => {
-                        if let Err(err) = compactor.major_compaction(level, scope, vec![]).await {
+                    CompactTask::Seek((scope, level)) => {
+                        if let Err(err) =
+                            compactor.major_compaction(level, scope, vec![], true).await
+                        {
                             error!("[Compactor][manual compaction][error happen]: {:?}", err);
                         }
                     }
@@ -270,7 +272,7 @@ impl KipStorage {
     pub async fn manual_compaction(&self, min: Bytes, max: Bytes, level: usize) -> Result<()> {
         if min <= max {
             self.compactor_tx
-                .send(CompactTask::Seek(Scope::from_range(0, min, max), level))
+                .send(CompactTask::Seek((Scope::from_range(0, min, max), level)))
                 .await?;
         }
 

--- a/src/kernel/lsm/storage.rs
+++ b/src/kernel/lsm/storage.rs
@@ -47,9 +47,7 @@ pub(crate) const DEFAULT_SST_FILE_SIZE: usize = 2 * 1024 * 1024;
 
 pub(crate) const DEFAULT_MAJOR_THRESHOLD_WITH_SST_SIZE: usize = 10;
 
-pub(crate) const DEFAULT_MAJOR_SELECT_FILE_SIZE: usize = 3;
-
-pub(crate) const DEFAULT_LEVEL_SST_MAGNIFICATION: usize = 5;
+pub(crate) const DEFAULT_LEVEL_SST_MAGNIFICATION: usize = 10;
 
 pub(crate) const DEFAULT_DESIRED_ERROR_PROB: f64 = 0.05;
 
@@ -288,11 +286,6 @@ pub struct Config {
     pub(crate) minor_trigger_with_threshold: (TriggerType, usize),
     /// Major压缩触发阈值
     pub(crate) major_threshold_with_sst_size: usize,
-    /// Major压缩选定文件数
-    /// Major压缩时通过选定个别SSTable(即该配置项)进行下一级的SSTable选定，
-    /// 并将确定范围的下一级SSTable再次对当前等级的SSTable进行范围判定，
-    /// 找到最合理的上下级数据范围并压缩
-    pub(crate) major_select_file_size: usize,
     /// 每级SSTable数量倍率
     pub(crate) level_sst_magnification: usize,
     /// 布隆过滤器 期望的错误概率
@@ -329,7 +322,6 @@ impl Config {
                 DEFAULT_MINOR_THRESHOLD_WITH_SIZE_WITH_MEM,
             ),
             major_threshold_with_sst_size: DEFAULT_MAJOR_THRESHOLD_WITH_SST_SIZE,
-            major_select_file_size: DEFAULT_MAJOR_SELECT_FILE_SIZE,
             level_sst_magnification: DEFAULT_LEVEL_SST_MAGNIFICATION,
             desired_error_prob: DEFAULT_DESIRED_ERROR_PROB,
             block_cache_size: DEFAULT_BLOCK_CACHE_SIZE,
@@ -407,12 +399,6 @@ impl Config {
     #[inline]
     pub fn major_threshold_with_sst_size(mut self, major_threshold_with_sst_size: usize) -> Self {
         self.major_threshold_with_sst_size = major_threshold_with_sst_size;
-        self
-    }
-
-    #[inline]
-    pub fn major_select_file_size(mut self, major_select_file_size: usize) -> Self {
-        self.major_select_file_size = major_select_file_size;
         self
     }
 

--- a/src/kernel/lsm/table/loader.rs
+++ b/src/kernel/lsm/table/loader.rs
@@ -56,7 +56,7 @@ impl TableLoader {
         table_type: TableType,
     ) -> Result<(Scope, TableMeta)> {
         // 获取数据的Key涵盖范围
-        let scope = Scope::from_vec_data(gen, &vec_data)?;
+        let scope = Scope::from_sorted_vec_data(gen, &vec_data)?;
         let table: Box<dyn Table> = match table_type {
             TableType::SortedString => Box::new(self.create_ss_table(gen, vec_data, level)?),
             TableType::Skip => Box::new(SkipTable::new(level, gen, vec_data)),

--- a/src/kernel/lsm/table/scope.rs
+++ b/src/kernel/lsm/table/scope.rs
@@ -4,28 +4,72 @@ use crate::KernelError;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::collections::Bound;
+use std::sync::atomic::Ordering::{Acquire, SeqCst};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+const SEEK_COMPACTION_COUNT: u32 = 20;
 
 /// 数据范围索引
 /// 用于缓存SSTable中所有数据的第一个和最后一个数据的Key
 /// 标明数据的范围以做到快速区域定位
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct Scope {
     pub(crate) start: Bytes,
     pub(crate) end: Bytes,
     gen: i64,
+    // SeekMiss计数
+    allowed_seeks: Option<Arc<AtomicU32>>,
+}
+
+impl PartialEq for Scope {
+    fn eq(&self, other: &Self) -> bool {
+        if let (Some(a), Some(b)) = (&self.allowed_seeks, &other.allowed_seeks) {
+            a.load(Acquire) == b.load(Acquire)
+                || self.start == other.start
+                || self.end == other.end
+                || self.gen == other.gen
+        } else {
+            false
+        }
+    }
 }
 
 impl Scope {
+    /// SeekMiss计数自增
+    /// 当跃出阈值且CAS重置成功时返回`true`
+    /// 表示应当触发阈值
+    pub(crate) fn seeks_increase(&self) -> bool {
+        if let Some(seeks) = &self.allowed_seeks {
+            let current = seeks.load(Ordering::Relaxed);
+            current > SEEK_COMPACTION_COUNT
+                && seeks.compare_exchange(current, 0, SeqCst, Acquire).is_ok()
+        } else {
+            false
+        }
+    }
+
     pub(crate) fn gen(&self) -> i64 {
         self.gen
     }
 
     /// 由KeyValue组成的Key构成scope
-    pub(crate) fn from_key(gen: i64, first: Bytes, last: Bytes) -> Self {
+    pub(crate) fn from_range(gen: i64, first: Bytes, last: Bytes) -> Self {
         Scope {
             start: first,
             end: last,
             gen,
+            allowed_seeks: Some(Arc::new(AtomicU32::new(0))),
+        }
+    }
+
+    pub(crate) fn from_key(key: &[u8]) -> Self {
+        let bytes = Bytes::copy_from_slice(key);
+        Scope {
+            start: bytes.clone(),
+            end: bytes,
+            gen: 0,
+            allowed_seeks: None,
         }
     }
 
@@ -34,7 +78,12 @@ impl Scope {
         let start = scopes.iter().map(|scope| &scope.start).min()?.clone();
         let end = scopes.iter().map(|scope| &scope.end).max()?.clone();
 
-        Some(Scope { start, end, gen: 0 })
+        Some(Scope {
+            start,
+            end,
+            gen: 0,
+            allowed_seeks: None,
+        })
     }
 
     /// 判断scope之间是否相交或包含
@@ -70,8 +119,8 @@ impl Scope {
     #[allow(clippy::pattern_type_mismatch)]
     pub(crate) fn from_sorted_vec_data(gen: i64, vec_mem_data: &Vec<KeyValue>) -> Result<Self> {
         match vec_mem_data.as_slice() {
-            [first, .., last] => Ok(Self::from_key(gen, first.0.clone(), last.0.clone())),
-            [one] => Ok(Self::from_key(gen, one.0.clone(), one.0.clone())),
+            [first, .., last] => Ok(Self::from_range(gen, first.0.clone(), last.0.clone())),
+            [one] => Ok(Self::from_range(gen, one.0.clone(), one.0.clone())),
             _ => Err(KernelError::DataEmpty),
         }
     }

--- a/src/kernel/lsm/table/scope.rs
+++ b/src/kernel/lsm/table/scope.rs
@@ -37,13 +37,15 @@ impl Scope {
         Some(Scope { start, end, gen: 0 })
     }
 
-    /// 判断scope之间是否相交
+    /// 判断scope之间是否相交或包含
     pub(crate) fn meet(&self, target: &Scope) -> bool {
         (self.start.le(&target.start) && self.end.ge(&target.start))
             || (self.start.le(&target.end) && self.end.ge(&target.end))
+            || (self.start.le(&target.start)) && self.end.ge(&target.end)
+            || (self.start.ge(&target.start)) && self.end.le(&target.end)
     }
 
-    /// 判断key与Scope是否相交
+    /// 判断key与Scope是否相交或包含
     pub(crate) fn meet_by_key(&self, key: &[u8]) -> bool {
         self.start.as_ref().le(key) && self.end.as_ref().ge(key)
     }
@@ -64,9 +66,9 @@ impl Scope {
         is_min_inside && is_max_inside
     }
 
-    /// 由一组KeyValue组成一个scope
+    /// 由一组有序KeyValue组成一个scope
     #[allow(clippy::pattern_type_mismatch)]
-    pub(crate) fn from_vec_data(gen: i64, vec_mem_data: &Vec<KeyValue>) -> Result<Self> {
+    pub(crate) fn from_sorted_vec_data(gen: i64, vec_mem_data: &Vec<KeyValue>) -> Result<Self> {
         match vec_mem_data.as_slice() {
             [first, .., last] => Ok(Self::from_key(gen, first.0.clone(), last.0.clone())),
             [one] => Ok(Self::from_key(gen, one.0.clone(), one.0.clone())),

--- a/src/kernel/lsm/table/scope.rs
+++ b/src/kernel/lsm/table/scope.rs
@@ -21,26 +21,18 @@ impl Scope {
     }
 
     /// 由KeyValue组成的Key构成scope
-    pub(crate) fn from_data(gen: i64, first: &KeyValue, last: &KeyValue) -> Self {
+    pub(crate) fn from_key(gen: i64, first: Bytes, last: Bytes) -> Self {
         Scope {
-            start: first.0.clone(),
-            end: last.0.clone(),
+            start: first,
+            end: last,
             gen,
         }
     }
 
     /// 将多个scope重组融合成一个scope
     pub(crate) fn fusion(scopes: &[Scope]) -> Option<Self> {
-        let start = scopes
-            .iter()
-            .map(|scope| &scope.start)
-            .min()?
-            .clone();
-        let end = scopes
-            .iter()
-            .map(|scope| &scope.end)
-            .max()?
-            .clone();
+        let start = scopes.iter().map(|scope| &scope.start).min()?.clone();
+        let end = scopes.iter().map(|scope| &scope.end).max()?.clone();
 
         Some(Scope { start, end, gen: 0 })
     }
@@ -76,8 +68,8 @@ impl Scope {
     #[allow(clippy::pattern_type_mismatch)]
     pub(crate) fn from_vec_data(gen: i64, vec_mem_data: &Vec<KeyValue>) -> Result<Self> {
         match vec_mem_data.as_slice() {
-            [first, .., last] => Ok(Self::from_data(gen, first, last)),
-            [one] => Ok(Self::from_data(gen, one, one)),
+            [first, .., last] => Ok(Self::from_key(gen, first.0.clone(), last.0.clone())),
+            [one] => Ok(Self::from_key(gen, one.0.clone(), one.0.clone())),
             _ => Err(KernelError::DataEmpty),
         }
     }

--- a/src/kernel/lsm/table/scope.rs
+++ b/src/kernel/lsm/table/scope.rs
@@ -16,7 +16,7 @@ pub(crate) struct Scope {
 }
 
 impl Scope {
-    pub(crate) fn get_gen(&self) -> i64 {
+    pub(crate) fn gen(&self) -> i64 {
         self.gen
     }
 
@@ -30,25 +30,19 @@ impl Scope {
     }
 
     /// 将多个scope重组融合成一个scope
-    pub(crate) fn fusion(scopes: &[Scope]) -> Result<Self> {
-        if !scopes.is_empty() {
-            let start = scopes
-                .iter()
-                .map(|scope| &scope.start)
-                .min()
-                .ok_or(KernelError::DataEmpty)?
-                .clone();
-            let end = scopes
-                .iter()
-                .map(|scope| &scope.end)
-                .max()
-                .ok_or(KernelError::DataEmpty)?
-                .clone();
+    pub(crate) fn fusion(scopes: &[Scope]) -> Option<Self> {
+        let start = scopes
+            .iter()
+            .map(|scope| &scope.start)
+            .min()?
+            .clone();
+        let end = scopes
+            .iter()
+            .map(|scope| &scope.end)
+            .max()?
+            .clone();
 
-            Ok(Scope { start, end, gen: 0 })
-        } else {
-            Err(KernelError::DataEmpty)
-        }
+        Some(Scope { start, end, gen: 0 })
     }
 
     /// 判断scope之间是否相交

--- a/src/kernel/lsm/table/skip_table/iter.rs
+++ b/src/kernel/lsm/table/skip_table/iter.rs
@@ -36,8 +36,7 @@ impl<'a> Iter<'a> for SkipTableIter<'a> {
         Ok(self
             .inner
             .as_mut()
-            .map(|iter| iter.next())
-            .flatten()
+            .and_then(|iter| iter.next())
             .map(item_clone))
     }
 

--- a/src/kernel/lsm/table/skip_table/mod.rs
+++ b/src/kernel/lsm/table/skip_table/mod.rs
@@ -47,6 +47,6 @@ impl Table for SkipTable {
     }
 
     fn iter<'a>(&'a self) -> crate::kernel::Result<Box<dyn Iter<'a, Item = KeyValue> + 'a>> {
-        Ok(Box::new(SkipTableIter::new(&self)))
+        Ok(Box::new(SkipTableIter::new(self)))
     }
 }

--- a/src/kernel/lsm/table/ss_table/mod.rs
+++ b/src/kernel/lsm/table/ss_table/mod.rs
@@ -232,7 +232,7 @@ impl Table for SSTable {
     }
 
     fn iter<'a>(&'a self) -> Result<Box<dyn Iter<'a, Item = KeyValue> + 'a>> {
-        Ok(SSTableIter::new(&self).map(Box::new)?)
+        Ok(SSTableIter::new(self).map(Box::new)?)
     }
 }
 

--- a/src/kernel/lsm/version/edit.rs
+++ b/src/kernel/lsm/version/edit.rs
@@ -3,7 +3,7 @@ use crate::kernel::lsm::table::scope::Scope;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub(crate) enum VersionEdit {
     /// ((Vec(gen), Level, TableMeta)
     DeleteFile((Vec<i64>, usize), TableMeta),

--- a/src/kernel/sled_storage.rs
+++ b/src/kernel/sled_storage.rs
@@ -7,12 +7,12 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 #[derive(Debug)]
-pub struct SledStore {
+pub struct SledStorage {
     data_base: Arc<Db>,
 }
 
 #[async_trait]
-impl Storage for SledStore {
+impl Storage for SledStorage {
     #[inline]
     fn name() -> &'static str
     where
@@ -25,7 +25,7 @@ impl Storage for SledStore {
     async fn open(path: impl Into<PathBuf> + Send) -> crate::kernel::Result<Self> {
         let db = Arc::new(sled::open(path.into())?);
 
-        Ok(SledStore { data_base: db })
+        Ok(SledStorage { data_base: db })
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@ clippy::dbg_macro,
 clippy::decimal_literal_representation,
 // clippy::default_numeric_fallback, too verbose when dealing with numbers
 clippy::disallowed_script_idents,
-clippy::else_if_without_else,
 clippy::exit,
 clippy::expect_used,
 clippy::filetype_is_file,

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -3,7 +3,7 @@ use crate::kernel::{options_none, ByteUtils, CommandData, Storage};
 use crate::net::connection::Connection;
 use crate::net::shutdown::Shutdown;
 use crate::net::{key_value_from_option, kv_encode_with_len, Result};
-use crate::proto::net_pb::{CommandOption, KeyValue};
+use crate::proto::net_pb::{CommandOption, KeyValue, KeyValueType, OptionType};
 use bytes::Bytes;
 use chrono::Local;
 use itertools::Itertools;
@@ -147,6 +147,34 @@ impl Listener {
     }
 }
 
+impl From<&CommandOption> for OptionType {
+    fn from(value: &CommandOption) -> Self {
+        match value.r#type {
+            0 => OptionType::Cmd,
+            1 => OptionType::BatchCmd,
+            2 => OptionType::Bytes,
+            4 => OptionType::SizeOfDisk,
+            5 => OptionType::Len,
+            6 => OptionType::Flush,
+            7 => OptionType::None,
+
+            _ => panic!("The command is not supported!")
+        }
+    }
+}
+
+impl From<&CommandOption> for KeyValueType {
+    fn from(value: &CommandOption) -> Self {
+        match value.r#type {
+            0 => KeyValueType::Get,
+            1 => KeyValueType::Set,
+            2 => KeyValueType::Remove,
+
+            _ => panic!("The command is not supported!")
+        }
+    }
+}
+
 impl Handler {
     async fn run(&mut self) -> Result<()> {
         while !self.shutdown.is_shutdown() {
@@ -159,23 +187,25 @@ impl Handler {
                 }
             };
 
-            match client_option.r#type {
-                0 => {
+            match OptionType::from(&client_option) {
+                OptionType::Cmd => {
                     // 不使用`CommandData::apply`是因为避免value的内存移动开销
-                    let KeyValue { key, value, r#type } = key_value_from_option(&client_option)?;
-                    let res_option = match r#type {
-                        1 => self
+                    let KeyValue { key, value, .. } = key_value_from_option(&client_option)?;
+                    let res_option = match KeyValueType::from(&client_option) {
+                        KeyValueType::Get => self.kv_store.get(&key).await
+                            .map(CommandOption::from)?,
+                        KeyValueType::Remove => self.kv_store.remove(&key).await
+                            .map(|_| options_none())?,
+                        KeyValueType::Set => self
                             .kv_store
                             .set(&key, Bytes::from(value))
                             .await
                             .map(|_| options_none())?,
-                        2 => self.kv_store.remove(&key).await.map(|_| options_none())?,
-                        _ => self.kv_store.get(&key).await.map(CommandOption::from)?,
                     };
 
                     self.connection.write(res_option).await?;
                 }
-                1 => {
+                OptionType::BatchCmd => {
                     let vec_cmd = ByteUtils::sharding_tag_bytes(&client_option.bytes)
                         .into_iter()
                         .filter_map(|vec_u8| KeyValue::decode(vec_u8).ok().map(CommandData::from))
@@ -203,15 +233,15 @@ impl Handler {
                         })
                         .await?;
                 }
-                4 => {
+                OptionType::SizeOfDisk => {
                     let size_of_disk = self.kv_store.size_of_disk().await?;
                     self.value_options(size_of_disk, 4).await?;
                 }
-                5 => {
+                OptionType::Len => {
                     let len = self.kv_store.len().await? as u64;
                     self.value_options(len, 5).await?;
                 }
-                6 => {
+                OptionType::Flush => {
                     self.kv_store.flush().await?;
                     self.connection
                         .write(CommandOption {
@@ -221,7 +251,7 @@ impl Handler {
                         })
                         .await?;
                 }
-                7 => {
+                OptionType::None => {
                     break;
                 }
                 _ => {}

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -148,6 +148,7 @@ impl Listener {
 }
 
 impl From<&CommandOption> for OptionType {
+    #[inline]
     fn from(value: &CommandOption) -> Self {
         match value.r#type {
             0 => OptionType::Cmd,
@@ -158,19 +159,20 @@ impl From<&CommandOption> for OptionType {
             6 => OptionType::Flush,
             7 => OptionType::None,
 
-            _ => panic!("The command is not supported!")
+            _ => panic!("The command is not supported!"),
         }
     }
 }
 
 impl From<&CommandOption> for KeyValueType {
+    #[inline]
     fn from(value: &CommandOption) -> Self {
         match value.r#type {
             0 => KeyValueType::Get,
             1 => KeyValueType::Set,
             2 => KeyValueType::Remove,
 
-            _ => panic!("The command is not supported!")
+            _ => panic!("The command is not supported!"),
         }
     }
 }
@@ -192,10 +194,12 @@ impl Handler {
                     // 不使用`CommandData::apply`是因为避免value的内存移动开销
                     let KeyValue { key, value, .. } = key_value_from_option(&client_option)?;
                     let res_option = match KeyValueType::from(&client_option) {
-                        KeyValueType::Get => self.kv_store.get(&key).await
-                            .map(CommandOption::from)?,
-                        KeyValueType::Remove => self.kv_store.remove(&key).await
-                            .map(|_| options_none())?,
+                        KeyValueType::Get => {
+                            self.kv_store.get(&key).await.map(CommandOption::from)?
+                        }
+                        KeyValueType::Remove => {
+                            self.kv_store.remove(&key).await.map(|_| options_none())?
+                        }
                         KeyValueType::Set => self
                             .kv_store
                             .set(&key, Bytes::from(value))

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -1,4 +1,4 @@
-use crate::kernel::lsm::storage::LsmStore;
+use crate::kernel::lsm::storage::KipStorage;
 use crate::kernel::{options_none, ByteUtils, CommandData, Storage};
 use crate::net::connection::Connection;
 use crate::net::shutdown::Shutdown;
@@ -21,7 +21,7 @@ const MAX_CONNECTIONS: usize = 250;
 /// 服务器监听器
 /// 用于监听端口的连接并分发给Handler进行多线程处理连接
 pub struct Listener {
-    kv_store_root: Arc<LsmStore>,
+    kv_store_root: Arc<KipStorage>,
     listener: TcpListener,
     limit_connections: Arc<Semaphore>,
     notify_shutdown: broadcast::Sender<()>,
@@ -32,7 +32,7 @@ pub struct Listener {
 /// 连接处理器
 /// 用于每个连接的响应处理
 struct Handler {
-    kv_store: Arc<LsmStore>,
+    kv_store: Arc<KipStorage>,
     connection: Connection,
     shutdown: Shutdown,
     // 用于与Listener保持连接而感应是否全部关闭
@@ -41,7 +41,7 @@ struct Handler {
 
 #[inline]
 pub async fn run(listener: TcpListener, shutdown: impl Future) -> Result<()> {
-    let kv_store_root = Arc::new(LsmStore::open("./data").await?);
+    let kv_store_root = Arc::new(KipStorage::open("./data").await?);
     let (notify_shutdown, _) = broadcast::channel(1);
     let (shutdown_complete_tx, shutdown_complete_rx) = mpsc::channel(1);
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use kip_db::kernel::io::{FileExtension, IoFactory, IoType};
-use kip_db::kernel::lsm::storage::LsmStore;
-use kip_db::kernel::sled_storage::SledStore;
+use kip_db::kernel::lsm::storage::KipStorage;
+use kip_db::kernel::sled_storage::SledStorage;
 use kip_db::kernel::Result;
 use kip_db::kernel::Storage;
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -10,8 +10,8 @@ use walkdir::WalkDir;
 
 #[test]
 fn get_stored_value() -> Result<()> {
-    get_stored_value_with_kv_store::<SledStore>()?;
-    get_stored_value_with_kv_store::<LsmStore>()?;
+    get_stored_value_with_kv_store::<SledStorage>()?;
+    get_stored_value_with_kv_store::<KipStorage>()?;
     Ok(())
 }
 
@@ -45,8 +45,8 @@ fn get_stored_value_with_kv_store<T: Storage>() -> Result<()> {
 // Should overwrite existent value.
 #[test]
 fn overwrite_value() -> Result<()> {
-    overwrite_value_with_kv_store::<SledStore>()?;
-    overwrite_value_with_kv_store::<LsmStore>()?;
+    overwrite_value_with_kv_store::<SledStorage>()?;
+    overwrite_value_with_kv_store::<KipStorage>()?;
 
     Ok(())
 }
@@ -94,8 +94,8 @@ fn overwrite_value_with_kv_store<T: Storage>() -> Result<()> {
 // Should get `None` when getting a non-existent key.
 #[test]
 fn get_non_existent_value() -> Result<()> {
-    get_non_existent_value_with_kv_store::<SledStore>()?;
-    get_non_existent_value_with_kv_store::<LsmStore>()?;
+    get_non_existent_value_with_kv_store::<SledStorage>()?;
+    get_non_existent_value_with_kv_store::<KipStorage>()?;
 
     Ok(())
 }
@@ -124,8 +124,8 @@ fn get_non_existent_value_with_kv_store<T: Storage>() -> Result<()> {
 
 #[test]
 fn remove_non_existent_key() -> Result<()> {
-    remove_non_existent_key_with_kv_store::<SledStore>()?;
-    remove_non_existent_key_with_kv_store::<LsmStore>()?;
+    remove_non_existent_key_with_kv_store::<SledStorage>()?;
+    remove_non_existent_key_with_kv_store::<KipStorage>()?;
 
     Ok(())
 }
@@ -143,8 +143,8 @@ fn remove_non_existent_key_with_kv_store<T: Storage>() -> Result<()> {
 
 #[test]
 fn remove_key() -> Result<()> {
-    remove_key_with_kv_store::<SledStore>()?;
-    remove_key_with_kv_store::<LsmStore>()?;
+    remove_key_with_kv_store::<SledStorage>()?;
+    remove_key_with_kv_store::<KipStorage>()?;
 
     Ok(())
 }
@@ -168,8 +168,8 @@ fn remove_key_with_kv_store<T: Storage>() -> Result<()> {
 // Test data correctness after compaction.
 #[test]
 fn compaction() -> Result<()> {
-    compaction_with_kv_store::<SledStore>()?;
-    compaction_with_kv_store::<LsmStore>()?;
+    compaction_with_kv_store::<SledStorage>()?;
+    compaction_with_kv_store::<KipStorage>()?;
 
     Ok(())
 }


### PR DESCRIPTION
### What problem does this PR solve?
Fixed the original MajorCompaction problem and supported Manual Compaction and Seek Compaction at the same time

### What is changed and how it works?
- Manual Compaction: added `manual_compaction` method to manually specify `level` and `range` for Major Compaction
- Seek Compaction: `Scope` adds `allowed_seeks` record query invalidation, and counts, and automatically uses itself as a parameter to perform Major Compaction on the upper level after reaching the threshold
- Major Compaction: fix the Scope interleaving problem caused by Level 1-6 in MajorCompaction

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
References: 
- https://github.com/KipData/KipDB/wiki/version-0.1.1-Features
- http://blog.mrcroxx.com/posts/code-reading/leveldb-made-simple/9-compaction/