### PR TITLE
fix(bench): fix `KipStorage` blocking when benchmark

### DIFF
--- a/src/bench/kernel_bench.rs
+++ b/src/bench/kernel_bench.rs
@@ -45,11 +45,6 @@ fn random(n: u32) -> u32 {
 }
 
 fn bulk_load<T: Storage>(c: &mut Criterion) {
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-
     let count = AtomicU32::new(0_u32);
     let bytes = |len| -> Vec<u8> {
         count
@@ -62,8 +57,14 @@ fn bulk_load<T: Storage>(c: &mut Criterion) {
     };
 
     let mut bench = |key_len, val_len| {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(8)
+            .enable_all()
+            .build()
+            .unwrap();
+
         let db = rt.block_on(async {
-            T::open(format!("{}: bulk_k{}_v{}", T::name(), key_len, val_len))
+            T::open(format!("{}_bulk_k{}_v{}", T::name(), key_len, val_len))
                 .await
                 .unwrap()
         });
@@ -83,12 +84,10 @@ fn bulk_load<T: Storage>(c: &mut Criterion) {
                 })
             },
         );
-        rt.block_on(async {
-            db.flush().await.unwrap();
-        });
+        rt.shutdown_background();
     };
 
-    for key_len in &[10_usize, 128, 256, 512] {
+    for key_len in &[10_usize, 128, 512] {
         for val_len in &[0_usize, 10, 128, 256, 512, 1024, 2048] {
             bench(*key_len, *val_len);
         }
@@ -97,11 +96,12 @@ fn bulk_load<T: Storage>(c: &mut Criterion) {
 
 fn monotonic_crud<T: Storage>(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(8)
         .enable_all()
         .build()
         .unwrap();
     rt.block_on(async {
-        let db = T::open(format!("{}: monotonic_crud", T::name()))
+        let db = T::open(format!("{}_monotonic_crud", T::name()))
             .await
             .unwrap();
 
@@ -138,13 +138,12 @@ fn random_crud<T: Storage>(c: &mut Criterion) {
     const SIZE: u32 = 65536;
 
     let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(8)
         .enable_all()
         .build()
         .unwrap();
     rt.block_on(async {
-        let db = T::open(format!("{}: random_crud", T::name()))
-            .await
-            .unwrap();
+        let db = T::open(format!("{}_random_crud", T::name())).await.unwrap();
 
         c.bench_function(&format!("Store: {}, random inserts", T::name()), |b| {
             b.iter(|| async {
@@ -170,6 +169,7 @@ fn random_crud<T: Storage>(c: &mut Criterion) {
 
 fn empty_opens<T: Storage>(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(8)
         .enable_all()
         .build()
         .unwrap();

--- a/src/kernel/lsm/compactor.rs
+++ b/src/kernel/lsm/compactor.rs
@@ -321,86 +321,81 @@ mod tests {
     use std::time::Instant;
     use tempfile::TempDir;
 
-    #[test]
-    fn test_lsm_major_compactor() -> Result<()> {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+    async fn test_lsm_major_compactor() -> Result<()> {
         let temp_dir = TempDir::new().expect("unable to create temporary working directory");
 
-        tokio_test::block_on(async move {
-            let times = 30_000;
-
-            let value = b"Stray birds of summer come to my window to sing and fly away.
+        let times = 30_000;
+        let value = b"Stray birds of summer come to my window to sing and fly away.
             And yellow leaves of autumn, which have no songs, flutter and fall
             there with a sign.";
 
-            // Tips: 此处由于倍率为1且阈值固定为4，因此容易导致Level 1高出阈值时候导致归并转移到Level 2时，
-            // 重复触发阈值，导致迁移到Level6之中，此情况是理想之中的
-            // 普通场景下每个Level之间的阈值数量是有倍数递增的，因此除了极限情况以外，不会发送这种逐级转移的现象
-            let config = Config::new(temp_dir.path().to_str().unwrap())
-                .major_threshold_with_sst_size(4)
-                .level_sst_magnification(1)
-                .minor_trigger_with_threshold(TriggerType::Count, 1000);
-            let kv_store = KipStorage::open_with_config(config).await?;
-            let mut vec_kv = Vec::new();
+        // Tips: 此处由于倍率为1且阈值固定为4，因此容易导致Level 1高出阈值时候导致归并转移到Level 2时，
+        // 重复触发阈值，导致迁移到Level6之中，此情况是理想之中的
+        // 普通场景下每个Level之间的阈值数量是有倍数递增的，因此除了极限情况以外，不会发送这种逐级转移的现象
+        let config = Config::new(temp_dir.path().to_str().unwrap())
+            .major_threshold_with_sst_size(4)
+            .level_sst_magnification(1)
+            .minor_trigger_with_threshold(TriggerType::Count, 1000);
+        let kv_store = KipStorage::open_with_config(config).await?;
+        let mut vec_kv = Vec::new();
 
-            for i in 0..times {
-                let vec_u8 = bincode::serialize(&i)?;
-                vec_kv.push((
-                    Bytes::from(vec_u8.clone()),
-                    Bytes::from(vec_u8.into_iter().chain(value.to_vec()).collect_vec()),
-                ));
+        for i in 0..times {
+            let vec_u8 = bincode::serialize(&i)?;
+            vec_kv.push((
+                Bytes::from(vec_u8.clone()),
+                Bytes::from(vec_u8.into_iter().chain(value.to_vec()).collect_vec()),
+            ));
+        }
+
+        let start = Instant::now();
+
+        assert_eq!(times % 1000, 0);
+
+        for i in 0..times / 1000 {
+            for j in 0..1000 {
+                kv_store
+                    .set(&vec_kv[i * 1000 + j].0, vec_kv[i * 1000 + j].1.clone())
+                    .await?;
             }
-
-            let start = Instant::now();
-
-            assert_eq!(times % 1000, 0);
-
-            for i in 0..times / 1000 {
-                for j in 0..1000 {
-                    kv_store
-                        .set(&vec_kv[i * 1000 + j].0, vec_kv[i * 1000 + j].1.clone())
-                        .await?;
-                }
-                kv_store.flush().await?;
-            }
-            println!("[set_for][Time: {:?}]", start.elapsed());
-
-            let version = kv_store.current_version().await;
-            let level_slice = &version.level_slice;
-            println!("MajorCompaction Test: {:#?}", level_slice);
-            assert!(!level_slice[0].is_empty());
-            assert!(
-                !level_slice[1].is_empty()
-                    || !level_slice[2].is_empty()
-                    || !level_slice[3].is_empty()
-                    || !level_slice[4].is_empty()
-                    || !level_slice[5].is_empty()
-                    || !level_slice[6].is_empty()
-            );
-
-            for (level, slice) in level_slice.into_iter().enumerate() {
-                if !slice.is_empty() && level != LEVEL_0 {
-                    let mut tmp_scope: Option<&Scope> = None;
-
-                    for scope in slice {
-                        if let Some(last_scope) = tmp_scope {
-                            assert!(last_scope.end < scope.start);
-                        }
-                        tmp_scope = Some(scope);
-                    }
-                }
-            }
-
-            assert_eq!(kv_store.len().await?, times);
-
-            let start = Instant::now();
-            for i in 0..times {
-                assert_eq!(kv_store.get(&vec_kv[i].0).await?, Some(vec_kv[i].1.clone()));
-            }
-            println!("[get_for][Time: {:?}]", start.elapsed());
             kv_store.flush().await?;
+        }
+        println!("[set_for][Time: {:?}]", start.elapsed());
 
-            Ok(())
-        })
+        let version = kv_store.current_version().await;
+        let level_slice = &version.level_slice;
+        println!("MajorCompaction Test: {:#?}", level_slice);
+        assert!(!level_slice[0].is_empty());
+        assert!(
+            !level_slice[1].is_empty()
+                || !level_slice[2].is_empty()
+                || !level_slice[3].is_empty()
+                || !level_slice[4].is_empty()
+                || !level_slice[5].is_empty()
+                || !level_slice[6].is_empty()
+        );
+
+        for (level, slice) in level_slice.into_iter().enumerate() {
+            if !slice.is_empty() && level != LEVEL_0 {
+                let mut tmp_scope: Option<&Scope> = None;
+
+                for scope in slice {
+                    if let Some(last_scope) = tmp_scope {
+                        assert!(last_scope.end < scope.start);
+                    }
+                    tmp_scope = Some(scope);
+                }
+            }
+        }
+
+        let start = Instant::now();
+        for i in 0..times {
+            assert_eq!(kv_store.get(&vec_kv[i].0).await?, Some(vec_kv[i].1.clone()));
+        }
+        println!("[get_for][Time: {:?}]", start.elapsed());
+        kv_store.flush().await?;
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
### What problem does this PR solve?
Fix the problem that KipStorage is always blocked during BenchMark
- Runtime drop not in time, still runs in other tests
- Runtime does not set multi-threading, resulting in untimely compaction

### What is changed and how it works?

### Code changes

- [ ] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
