### PR TITLE
feat: support `check_key_conflict` for mvcc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kip_db"
-version = "0.1.2-alpha.18"
+version = "0.1.2-alpha.19"
 edition = "2021"
 authors = ["Kould <kould2333@gmail.com>"]
 description = "轻量级、异步 基于LSM Leveled Compaction K-V数据库"

--- a/examples/mvcc.rs
+++ b/examples/mvcc.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), KernelError> {
     let kip_storage = KipStorage::open_with_config(config).await?;
 
     println!("New Transaction");
-    let mut tx = kip_storage.new_transaction(CheckType::None).await;
+    let mut tx = kip_storage.new_transaction(CheckType::Optimistic).await;
 
     println!("Set KeyValue after the transaction -> (key_1, value_1)");
     kip_storage

--- a/examples/mvcc.rs
+++ b/examples/mvcc.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use kip_db::kernel::lsm::mvcc::CheckType;
 use kip_db::kernel::lsm::storage::{Config, KipStorage};
 use kip_db::kernel::Storage;
 use kip_db::KernelError;
@@ -11,7 +12,7 @@ async fn main() -> Result<(), KernelError> {
     let kip_storage = KipStorage::open_with_config(config).await?;
 
     println!("New Transaction");
-    let mut tx = kip_storage.new_transaction().await;
+    let mut tx = kip_storage.new_transaction(CheckType::None).await;
 
     println!("Set KeyValue after the transaction -> (key_1, value_1)");
     kip_storage

--- a/examples/scan_read.rs
+++ b/examples/scan_read.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), KernelError> {
         .await?;
 
     println!("New Transaction");
-    let tx = kip_storage.new_transaction(CheckType::None).await;
+    let tx = kip_storage.new_transaction(CheckType::Optimistic).await;
 
     println!("Iter without key_3 By Transaction:");
     let mut iter = tx.iter(Bound::Unbounded, Bound::Excluded(b"key_3"))?;

--- a/examples/scan_read.rs
+++ b/examples/scan_read.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use kip_db::kernel::lsm::iterator::Iter;
+use kip_db::kernel::lsm::mvcc::CheckType;
 use kip_db::kernel::lsm::storage::{Config, KipStorage};
 use kip_db::kernel::Storage;
 use kip_db::KernelError;
@@ -35,7 +36,7 @@ async fn main() -> Result<(), KernelError> {
         .await?;
 
     println!("New Transaction");
-    let tx = kip_storage.new_transaction().await;
+    let tx = kip_storage.new_transaction(CheckType::None).await;
 
     println!("Iter without key_3 By Transaction:");
     let mut iter = tx.iter(Bound::Unbounded, Bound::Excluded(b"key_3"))?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,7 +72,7 @@ pub enum KernelError {
     #[error("Process already exists")]
     ProcessExists,
 
-    #[error("channel is closed")]
+    #[error("Channel is closed")]
     ChannelClose,
 
     #[error("{0}")]
@@ -80,6 +80,9 @@ pub enum KernelError {
 
     #[error("The number of caches cannot be divisible by the number of shards")]
     ShardingNotAlign,
+
+    #[error("Same write in different transactions")]
+    RepeatedWrite,
 }
 
 #[derive(Error, Debug)]

--- a/src/kernel/lsm/mem_table.rs
+++ b/src/kernel/lsm/mem_table.rs
@@ -543,9 +543,9 @@ mod tests {
         let _ = mem_table.insert_data_with_seq(kv_1.clone(), 2)?;
         let _ = mem_table.insert_data_with_seq(kv_2.clone(), 3)?;
 
-        assert!(mem_table.check_key_conflict(&vec![kv_1.clone()], 1));
+        assert!(mem_table.check_key_conflict(&[kv_1.clone()], 1));
 
-        assert!(!mem_table.check_key_conflict(&vec![kv_1.clone()], 2));
+        assert!(!mem_table.check_key_conflict(&[kv_1.clone()], 2));
 
         Ok(())
     }

--- a/src/kernel/lsm/mvcc.rs
+++ b/src/kernel/lsm/mvcc.rs
@@ -30,7 +30,6 @@ unsafe impl Sync for BufPtr {}
 struct BufPtr(NonNull<Vec<KeyValue>>);
 
 pub enum CheckType {
-    None,
     Optimistic,
 }
 
@@ -89,7 +88,6 @@ impl Transaction {
             let batch_data = buf.into_iter().collect_vec();
 
             match self.check_type {
-                CheckType::None => (),
                 CheckType::Optimistic => {
                     if self
                         .mem_table()
@@ -350,7 +348,7 @@ mod tests {
             kv_store.set(kv.0.clone(), kv.1.clone()).await?;
         }
 
-        let mut tx_1 = kv_store.new_transaction(CheckType::None).await;
+        let mut tx_1 = kv_store.new_transaction(CheckType::Optimistic).await;
 
         for kv in vec_kv.iter().take(times).skip(100) {
             tx_1.set(kv.0.clone(), kv.1.clone());
@@ -402,7 +400,7 @@ mod tests {
         let config = Config::new(temp_dir.into_path()).major_threshold_with_sst_size(4);
         let kv_store = KipStorage::open_with_config(config).await?;
 
-        let mut tx_1 = kv_store.new_transaction(CheckType::None).await;
+        let mut tx_1 = kv_store.new_transaction(CheckType::Optimistic).await;
         let mut tx_2 = kv_store.new_transaction(CheckType::Optimistic).await;
 
         tx_1.set(Bytes::from("same_key"), Bytes::new());

--- a/src/kernel/lsm/storage.rs
+++ b/src/kernel/lsm/storage.rs
@@ -1,7 +1,7 @@
 use crate::kernel::io::IoType;
 use crate::kernel::lsm::compactor::{CompactTask, Compactor};
 use crate::kernel::lsm::mem_table::{KeyValue, MemTable};
-use crate::kernel::lsm::mvcc::Transaction;
+use crate::kernel::lsm::mvcc::{CheckType, Transaction};
 use crate::kernel::lsm::table::scope::Scope;
 use crate::kernel::lsm::table::ss_table::block;
 use crate::kernel::lsm::table::TableType;
@@ -243,7 +243,7 @@ impl KipStorage {
 
     /// 创建事务
     #[inline]
-    pub async fn new_transaction(&self) -> Transaction {
+    pub async fn new_transaction(&self, check_type: CheckType) -> Transaction {
         let _ = self.mem_table().tx_count.fetch_add(1, Ordering::Release);
 
         Transaction {
@@ -253,6 +253,7 @@ impl KipStorage {
 
             seq_id: Sequence::create(),
             write_buf: None,
+            check_type,
         }
     }
 

--- a/src/kernel/lsm/table/btree_table/iter.rs
+++ b/src/kernel/lsm/table/btree_table/iter.rs
@@ -103,10 +103,7 @@ mod tests {
 
         assert_eq!(iter.seek(Seek::First)?, Some(vec[0].clone()));
 
-        assert_eq!(
-            iter.seek(Seek::Backward(&[b'3']))?,
-            Some(vec[2].clone())
-        );
+        assert_eq!(iter.seek(Seek::Backward(&[b'3']))?, Some(vec[2].clone()));
 
         assert_eq!(iter.seek(Seek::Last)?, Some(vec[5].clone()));
 


### PR DESCRIPTION
### What problem does this PR solve?

Refer to RocksDB's optimistic write conflict implementation and perform conflict key checking during Transaction submission

Tips: This feature is mainly designed to solve the key conflict problem during DDL or Index maintenance in KipSQL

### What is changed and how it works?

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
